### PR TITLE
Added webpack alias

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,9 @@ module.exports = {
   resolve: {
     modules: ['node_modules'],
     extensions: ['.js', '.jsx'],
+    alias: {
+      '@': path.join(__dirname, 'src'),
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
This makes it easier to import files when you're a few levels in.

The `@` location refers to the `src` directory.

For example, in my `components/relatedProducts/index.jsx` file, to import my stylesheet, I had to use `../../styles/relatedProducts.css`. Now, anything can be referenced directly from `src` to become `@/styles/relatedProducts.css`.